### PR TITLE
EDSL Implementation Strategy: Visitors

### DIFF
--- a/trees.py
+++ b/trees.py
@@ -1,0 +1,120 @@
+#!/usr/bin/env python3
+
+class TreeVisitor:
+    def leaf(self, v): pass
+    def node(self, l, r): pass
+
+class Tree:
+    def internal(self, visitor: TreeVisitor): pass
+    def external(self, visitor: TreeVisitor): pass
+
+class Leaf(Tree):
+    def __init__(self, v):
+        self.v = v
+    def internal(self, visitor: TreeVisitor):
+        return visitor.leaf(self.v)
+    def external(self, visitor: TreeVisitor):
+        return visitor.leaf(self.v)
+
+class Node(Tree):
+    def __init__(self, l, r):
+        self.l = l
+        self.r = r
+    def internal(self, visitor: TreeVisitor):
+        return visitor.node(self.l.internal(visitor), self.r.internal(visitor))
+    def external(self, visitor: TreeVisitor):
+        return visitor.node(self.l, self.r)
+
+class LowerCasePrinter(TreeVisitor):
+    def leaf(self, v):
+        return f'leaf({v})'
+    def node(self, l, r):
+        return f'node({l}, {r})'
+
+class UpperCasePrinter(TreeVisitor):
+    def leaf(self, v):
+        return f'LEAF({v})'
+    def node(self, l, r):
+        return f'NODE({l}, {r})'
+
+# Allowing the script to choose between different interpretations.
+class UpperCase(Tree):
+    def __init__(self, tree):
+        self.tree = tree
+    def internal(self, visitor):
+        return visitor.upperCase(self.tree.internal(visitor))
+    def external(self, visitor):
+        return visitor.upperCase(self.tree)
+
+class LowerCase(Tree):
+    def __init__(self, tree):
+        self.tree = tree
+    def internal(self, visitor):
+        return visitor.lowerCase(self.tree.internal(visitor))
+    def external(self, visitor):
+        return visitor.lowerCase(self.tree)
+
+# External visitor because we need to push down information, the mode, from
+# root to leaves.
+#
+# I think this visitor is monadic, in a way, because the interpretation depends
+# on user input. Or maybe `Selective`, as the name hints. Not quite monadic
+# because the possible computations from which we select based on user input is
+# fixed.
+class Dispatching(TreeVisitor):
+    def __init__(self):
+        self.modes = {
+            'lower': LowerCasePrinter(),
+            'upper': UpperCasePrinter(),
+        }
+    def leaf(self, v):
+        return lambda mode: self.modes[mode].leaf(v)
+    def node(self, l, r):
+        return lambda mode: self.modes[mode].node(
+            l.external(self)(mode),
+            r.external(self)(mode),
+        )
+    def upperCase(self, t):
+        return lambda _: t.external(self)('upper')
+    def lowerCase(self, t):
+        return lambda _: t.external(self)('lower')
+
+# This visitor is neither external, nor internal. It just delegates to the
+# inner `Dispatching` visitor and supplies the default/start_mode at the end.
+# However, it must be used as an external visitor because `Dispatching` is
+# external.
+class SwitchingCase(TreeVisitor):
+    def __init__(self):
+        self.dispatching = Dispatching()
+        self.start_mode = 'lower'
+    def leaf(self, v):
+        return self.dispatching.leaf(v)(self.start_mode)
+    def node(self, l, r):
+        return self.dispatching.node(l, r)(self.start_mode)
+    def upperCase(self, t):
+        return self.dispatching.upperCase(t)(self.start_mode)
+    def lowerCase(self, t):
+        return self.dispatching.lowerCase(t)(self.start_mode)
+
+tree = Node(
+    Node(
+        Leaf(1),
+        Node(Leaf(2), Leaf(3)),
+    ),
+    Node(Leaf(4), Leaf(5)),
+)
+
+print(tree.internal(LowerCasePrinter()))
+print(tree.internal(UpperCasePrinter()))
+
+tree = Node(
+    UpperCase(Node(
+        LowerCase(Leaf(1)),
+        Node(Leaf(2), Leaf(3)),
+    )),
+    Node(Leaf(4), Leaf(5)),
+)
+
+print(tree.external(Dispatching())('upper'))
+print(tree.external(Dispatching())('lower'))
+print(tree.external(SwitchingCase()))


### PR DESCRIPTION
Salut, Dan! E un răspuns incomplet față de ce intenționam eu, dar cred că oricum e mult. Sper să fie inteligibil, pentru că în ultima vreme am impresia că mi-am pierdut capacitatea de a mă face înțeles.

Am ales să deschid un pull-request ca să pot adăuga o versiune executabilă a ceea ce e scris mai jos, iar în caz că simți nevoia, să poți lăsa comentariu direct la linia de cod cu pricina. Acestea fiind zise...

Cred că abordarea cu care ai pornit tu, acel shallow embedding, e ok atâta timp cât ai o singură intepretare. Dar din ce-mi dau eu seama, dacă vrei să ai ceva similar cu acel `TrailLike` type class, atunci cred că ai nevoie de un deep embedding. Spun asta pentru că mi se pare că mașinăria de type classes din Haskell oferă posibilitatea de interpretări diferite, dar păstrând totuși un shallow embedding. Cum Python n-are type classes, trebuie găsită altă soluție, și de asta am încercat să merg pe ideea de deep embedding în Python. Am aflat de curând că Python introduce pattern matching începând cu 3.10, dar o să merg pe o soluție validă și în versiunile anterioare — visitors.

Mi-aduc vag aminte c-am mai vorbit noi despre visitor în Python, dar o să încerc să descriu iarăși conceptul că știu că e un pic hairy.

## Visitors

Dacă în Haskell am avea reprezentarea asta pentru un arbore:

```haskell
data Tree = Leaf String | Node (Tree a) (Tree a)
```

Atunci echivalentul provizoriu în Python ar putea arată cam așa (`Tree` e probabil inutil fără suport `mypy`, dar o las așa deocamdată):

```python
class Tree: pass

class Leaf(Tree):
    def __init__(self, a):
      self.a = a

class Node(Tree)
    def __init__(self, l, r):
      self.l = l
      self.r = r
```

Conceptul de visitor intervine când vrem să imităm partea de pattern matching din Haskell:

```haskell
-- Nu știu dacă e sintaxa corectă, ideea contează.
showTree tree =
  case tree of
    Leaf a -> "Leaf " ++ a
    -- Notice the recursive `showTree` calls
    Node l r -> "Node (" ++ showTree l ++ ") (" ++ showTree r ++ ")"
```

O să redefinesc acum clasele de mai sus ca să țină cont și de partea de "vizitare":

```python
# Interface-like
class TreeVisitor:
    def leaf(self, a): pass
    def node(self, l, r): pass

# Interface-like
class Tree:
    def visit(self, visitor: TreeVisitor): pass

class Leaf(Tree):
    def __init__(self, a):
      self.a = a

    def visit(self, visitor: TreeVisitor):
        return visitor.leaf(self.a)

class Node(Tree)
    def __init__(self, l, r):
        self.l = l
        self.r = r

    def visit(self, visitor: TreeVisitor):
        return visitor.node(self.l, self.r)

class ShowVisitor(TreeVisitor):
    def leaf(self, a):
        return f'Leaf({a})'
    def node(self, l, r):
        # Notice the recursive `visit` calls
        return f'Tree({l.visit(self)}, {r.visit(self)})'

def show(tree: Tree):
    return tree.visitor(ShowVisitor())
```

După cum vezi, metoda `visit` a fiecărei variante e responsabilă să apeleze metoda corespunzătoare din visitor-ul primit. Iar semnătura lui `TreeVisitor` este aproape identică cu alternativele din `case ... of`; la fel și implementarea `ShowVisitor`. Visitor nu știe de nested pattern matching, dar e ok pentru moment.

### Internal Visitors

Bun, avem acum o modalitate să encodăm un AST și să-l traversăm. Există însă o alternativă în Haskell pentru a exprima transformări (posibil recursive) pe ADTs, prin folds/catamorphims:

```haskell
data Tree = Leaf String | Node (Tree a) (Tree a)

foldTree tree leaf node =
  case tree of
    Leaf a -> leaf a
    -- Notice again the recursive calls
    Node l r -> node (foldTree l leaf node) (foldTree r leaf node)

-- Acum putem scrie `show` de manieră non-recursivă:
showTree tree = foldTree tree leaf node
  where
    leaf a = "Leaf " ++ a
    -- no recursive calls this time, `l` and `r` are already strings
    node l r = "Node (" ++ l ++ ") (" ++ r ++ ")"
```

În varianta catamorfică, recursivitatea este internă fold-ului, iar rezultatul e calculat bottom-up, dinspre frunze în sus. În varianta externă, rezultatul e calculat top-down, dinspre rădăcina copacului spre frunze.

Putem să portăm și treaba asta în Python. În lumea OOP, visitors sunt clasificați ca fiind _external_ sau _internal_ în funcție de cine se ocupă de punctele recursive, fix ca în varianta Haskell.

```python
# Interfața asta rămâne la fel pentru că Python e dynamically typed, iar
# punctele recursive ale lui `Tree` — `l` și `r` — pot lua tipuri diferite
# în funcție de metoda de vizitare cu care e folosit visitorul.
class TreeVisitor:
    def leaf(self, a): pass
    def node(self, l, r): pass

# Interface-like
class Tree:
    # Am redenumit din `visit` în `external` ca să fac loc celeilalte
    # strategii de vizitare: `internal`.
    def external(self, visitor: TreeVisitor): pass
    def internal(self, visitor: TreeVisitor): pass

class Leaf(Tree):
    def __init__(self, a):
      self.a = a

    # Implementările sunt identifice pentru că nu există puncte recursive în
    # definiția lui `Leaf`.
    def external(self, visitor: TreeVisitor):
        return visitor.leaf(self.a)
    def internal(self, visitor: TreeVisitor):
        return visitor.leaf(self.a)

class Node(Tree)
    def __init__(self, l, r):
        self.l = l
        self.r = r

    def external(self, visitor: TreeVisitor):
        return visitor.node(self.l, self.r)
    def internal(self, visitor: TreeVisitor):
        return visitor.node(
            self.l.internal(visitor), # recursive calls handled here
            self.r.internal(visitor),
        )

    # Dacă vrem să fim snobi...
    cata = internal

# Acum putem rescrie `ShowVisitor` ca un catamorphism:
class ShowVisitor(TreeVisitor):
    def leaf(self, a):
        return f'Leaf({a})'
    def node(self, l, r):
        # No more recursive calls, the children are already strings.
        return f'Tree({l}, {r})'

def show(tree: Tree):
    return tree.internal(ShowVisitor())
```

Avem acum _două_ strategii prin care putem procesa AST-ul unui deep EDSL. În general, aici m-am blocat la fiecare tentativă de a-ți scrie, pentru că invevitabil am încercat să explorez cum ar arată alte morfisme, nu doar catamorfismele, într-un context visitor-based. Am vrut să văd dacă se poate porta toată panoplia de _recursion schemes_ într-un context OOP, visitor-based. Am avut success cu câteva, dar nu intru în ele acum că prezintă complexitate nenecesară.

## Multiple Interpretations

Să presupunem acum că avem două modalidăți de a arăta un arbore, una lower-case, iar cealaltă upper-case:

```python
class LowerCasePrinter(TreeVisitor):
    def leaf(self, v):
        return f'leaf({v})'
    def node(self, l, r):
        return f'node({l}, {r})'

class UpperCasePrinter(TreeVisitor):
    def leaf(self, v):
        return f'LEAF({v})'
    def node(self, l, r):
        return f'NODE({l}, {r})'

tree = Node(
    Node(
        Leaf(1),
        Node(Leaf(2), Leaf(3)),
    ),
    Node(Leaf(4), Leaf(5)),
)

print(tree.internal(LowerCasePrinter))
# node(node(leaf(1), node(leaf(2), leaf(3))), node(leaf(4), leaf(5)))

print(tree.internal(UpperCasePrinter))
# NODE(NODE(LEAF(1), NODE(LEAF(2), LEAF(3))), NODE(LEAF(4), LEAF(5)))
```

Ăsta ar fi un exemplu redus pentru ideea de `TrailLike` din `diagrams`. Scriptul exprimat în EDSL arată la fel, dar vrem să-l interpretăm diferit. E ușor să dictăm interpretarea odată ce avem scriptul deja construit, dar nu putem să schimbăm interpretarea _dinăuntrul_ scriptului (o să numesc _script_ un program exprimat cu ajutorul EDSL-ului).

Am văzut că `diagrams` se folosește de tipuri și de mecanismul de typeclass resolution pentru a "injecta" implementări diferite în funcție de interpretarea pe care o vrei:

```haskell
example = (ts ||| strokeP ts ||| strokeLine ts ||| fromVertices ts) # fc red
```

Mai sus `strokeP`, `strokeLine` și `fromVertices` sunt un fel de markeri care schimbă modul de interpretare. Similar cumva cu tag-ul HTML `<strong>`, să zicem. Și asta mi-a dat ideea de a introduce tipuri noi de noduri în EDSL care au doar scop de decorare, în așa fel încât să putem delinia în script locul în care vrem o interpretare sau alta:

```python
tree = Node(
    UpperCase(Node(
        LowerCase(Leaf(1)),
        Node(Leaf(2), Leaf(3)),
    )),
    Node(Leaf(4), Leaf(5)),
)
```

Mai sus, `LowerCase` și `UpperCase` servesc doar ca adnotări, sau decoratori dacă vrei, în cadrul EDSL-ului. Declarația lor arată așa (trebuie să extindem și interfața vizitatorului ca să acomodeze noile cazuri):

```python
class TreeVisitorWithCaseDecorators(TreeVisitor):
    def upperCase(self, tree): pass
    def lowerCase(self, tree): pass

class UpperCase(Tree):
    def __init__(self, tree):
        self.tree = tree
    def external(self, visitor: TreeVisitorWithCaseDecorators):
        return visitor.upperCase(self.tree)
    def internal(self, visitor: TreeVisitorWithCaseDecorators):
        return visitor.upperCase(self.tree.internal(visitor))

class LowerCase(Tree):
    def __init__(self, tree):
        self.tree = tree
    def external(self, visitor: TreeVisitorWithCaseDecorators):
        return visitor.lowerCase(self.tree)
    def internal(self, visitor: TreeVisitorWithCaseDecorators):
        return visitor.lowerCase(self.tree.internal(visitor))
```

OK, deci acum `Tree` a ajuns să conțină patru variante:

  - `Leaf`
  - `Node`
  - `LowerCase`
  - `UpperCase`

Ne trebuie acum o interpretare hibridă, care să țină cont de adnotări și în funcție de ele să schimbe între interpretările "primitive":

```python
class Dispatching(TreeVisitorWithCaseDecorators):
    def __init__(self):
        self.modes = {
            'lower': LowerCasePrinter(),
            'upper': UpperCasePrinter(),
        }
    def leaf(self, v):
        return lambda mode: self.modes[mode].leaf(v)

    # `Dispatching` e gândit a fi folosit ca și external visitor pentru că
    # are nevoie să propage informație în jos: modul de printare, lower sau
    # upper.
    #
    # De asemenea, a se remarca faptul că se pasează pe el însuși, via
    # `node.external(self)`, ca să se asigure că și nodurile copii sunt
    # interpretate tot de `Dispatching`.
    def node(self, l, r):
        return lambda mode: self.modes[mode].node(
            l.external(self)(mode),
            r.external(self)(mode),
        )
    def upperCase(self, t):
        return lambda _: t.external(self)('upper') # switch mode in sub-tree
    def lowerCase(self, t):
        return lambda _: t.external(self)('lower') # switch mode in sub-tree
```

I-am spus `Dispatching` pentru că face dispatch între vizitatori "primitivi" în funcție de adnotările pe care le întâlnește pe drum în timp ce coboară de-a lungul ramurilor din arbore :)

Acum putem rula un script cu "user-specified annotations":

```python
tree = Node(
    UpperCase(Node(
        LowerCase(Leaf(1)),
        Node(Leaf(2), Leaf(3)),
    )),
    Node(Leaf(4), Leaf(5)),
)

print(tree.external(Dispatching())('upper')) # default mode is upper
# NODE(NODE(leaf(1), NODE(LEAF(2), LEAF(3))), NODE(LEAF(4), LEAF(5)))

print(tree.external(Dispatching())('lower')) # default mode is lower
# node(NODE(leaf(1), NODE(LEAF(2), LEAF(3))), node(leaf(4), leaf(5)))
```

Îmi închipui că aceeași strategie s-ar putea utiliza și pentru a implementa cele 4 tipuri de interpretări pe care le oferă diagrams: `Diagram` (default), `strokeP`, `strokeLine` și `fromVertices`.

## Stateful Traversals

### Top-Down

Vizitatorul de mai sus, `Dispatching`, demonstrează și cum se poate scrie un EDSL interpeter care să mențină stare pe timpul traversării — rezultatul vizitării e o funcție. Se poate în felul ăsta propaga în jos un background sau stroke color la copii.

### Bottom-Up

Pentru propagarea state-ului de jos în sus, lucrurile stau mai simplu, se poate pur și simplu returna un tuple sau orice alt obiect compus.

## Drawing EDSL

Făcând research în zona asta, de EDSL-uri pentru imagini, am ajuns să studiez și o bibliotecă scrisă în Scala, [Doodle](https://github.com/creativescala/doodle), pentru că mi-a fost mult mai ușor s-o lecturez față de ce e în `diagrams`, deci ceea ce voi descrie e influențat destul de mult de ea.

Am încercat să scriu o gramatică BNF minimală care să descrie un drawing EDSL și am ajuns la treaba asta:

```
transform ::= "rotate" angle
            | "translate" ...
            | ...

color ::= "red" | "green" | "blue" | ...
        | "rgb" float float float
        | ...

image ::= "empty"               ;; primitives
        | "square" float
        | "circle" float float
        | ...

        | image "beside" image  ;; combinators
        | image "atop" image
        | ...

        | image transform       ;; decorators
        | image "strokeColor" color
        | image "strokeWidth" float
        | "stroke_path" image
        | "stroke_line" image
        | "as_vertices" image
        | ...
```

Câteva detalii sunt irelevante, însă partea care mi s-a părut mie utilă a fost faptul c-am putut distinge o secțiune de "decorators". N-am încercat să traduc toată gramatica asta în Python, dar mi se pare că procesul de mapare de la BNF la clase e destul de mecanic.

La partea de interpretare mi se pare că se pot distinge apoi câteva _faze_:

  1. push down: styling
  2. push down: transforms
  3. bubble up: envelope or bounding box data
  4. bubble up: translation to lower-level pycairo calls

După cum vezi, am transformat problema destul de mult într-una de interpretoare/compilatoare. Ideal fiecare fază din asta ar fi scrisă separat, ca o instanță de visitor, iar apoi acești visitors combinați pentru a obține un "fat visitor" care face interpretarea și randarea completă a unui script.

Ăsta iar e un punct în care m-am împotmolit, pentru că overlap-ul cu partea de recursion schemes, mai ales acele schemes are fac fusion, pare a fi destul de mare.

Varianta naivă ar fi să scrii un singur mare visitor care se ocupă de toate fazele și care menține starea pentru toate fazele. Poate nu e o idee așa de rea având în vedere cât de simplu pare a fi EDSL-ul, dar ceva îmi spune că lucrurile ar putea deveni foarte complicate în momentul în care vrei să ai interpretări diferite: `stroke_path`, `stroke_line`, `as_vertices`.

## Dropping Explicit Nodes

Pentru tot ce-am discutat, am folosit o reprezentare explicită a AST-ului, adică fix acel deep embedding. Există totuși un trend în lumea Scala în care se dă skip la partea de noduri și se lucrează doar cu visitors, deși strategia e numită _final tagless_ în loc de visitors. Ideea ar fi că în loc să construiești noduri AST în script, să apelezi direct metode ale visitorului, care devine acum un parametru al scriptului.

Ceea ce înainte era:

```python
tree = Node(
    UpperCase(Node(
        LowerCase(Leaf(1)),
        Node(Leaf(2), Leaf(3)),
    )),
    Node(Leaf(4), Leaf(5)),
)
```

Ar fi acum:

```python
def tree(dsl: TreeVisitorWithCaseDecorators):
    return dsl.node(
        dsl.upperCase(dsl.node(
            dsl.lowerCase(dsl.leaf(1)),
            dsl.node(dsl.leaf(2), dsl.leaf(3)),
        )),
        dsl.node(dsl.leaf(4), dsl.leaf(5)),
    )
```

Arată un pic mai urât, dar în teorie are avantajul că nu trebuie să mai construiești structura de date, AST-ul. Se revine practic la un shallow embedding.

## Syntactic Sugar / Surface Language

Pentru DX/API mi se pare mai util însă să ai un AST explicit, pentru că te poți folosi atunci de OOP methods ca să reprezinți unele noduri. De pildă, în gramatica BNF de mai sus, ceea ce intră la categoria combinators și decorators se poate reprezenta ca și metode. Primitivele și combinatorii care combină mai mult de două imagini le-aș reprezenta ca funcții însă, asta pentru că e ușor să le imporți global în modulul tău. Dacă ar fi declarate ca și static/class methods trebuiesc mereu prefixate cu numele clasei în Python (cel puțin eu așa știu). Deci un script de genul (care nu știu cât sens are...):

```python
image = Beside(
    StrokeWidth(StrokeColor(Square(3), 'green'), 5)
    AsVertices(StrokeWidth(StrokeColor(Square(5), 'red'), 3))
)
```

Ar arăta cam așa:

```python
image = square(3).strokeColor('green').strokeWidth(5).beside(
    square(5).strokeColor('red').strokeWidth(3).asVertices()
)
```

Poate nu e cu mult mai bine, dar măcar nu mai arată ca și când construiești AST-ul de mână.


Mă opresc aici, și așa am scris o groază, dar am de gând să mai sap în weekend pentru că vreau să-mi fie mai comod să fac design și implementare de EDSL-uri; să am niște reguli relativ clare despre ce drumuri trebuiesc explorate.
